### PR TITLE
Updated for installApp to work with SDK 24 and higher

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -36,6 +36,59 @@ $ react-native link react-native-apk
      compile project(':react-native-apk')
    ```
 
+#### SDK 24 and higher
+
+As of SDK version 24 (7.0) Android requires you to set up a Fileprovider for installing apks. To do so add the following to your AndroidManifest.xml file:
+```
+   <application>
+   ...
+    <provider
+      android:name="android.support.v4.content.FileProvider"
+      android:authorities="${applicationId}.fileprovider"
+      android:exported="false"
+      android:grantUriPermissions="true">
+        <meta-data
+          android:name="android.support.FILE_PROVIDER_PATHS"
+          android:resource="@xml/filepaths" />
+    </provider>
+
+  </application>
+```
+
+In android/app/src/main/res/xml folder (create it if it does not exist) add a file named filepaths.xml and paste the following contents:
+```
+  <?xml version="1.0" encoding="utf-8"?>
+  <paths xmlns:android="http://schemas.android.com/apk/res/android">
+      <!-- Select one of the following based on your apk location -->
+      
+      <cache-path name="cache" path="/"/>
+      <!-- <files-path name="name" path="/" />  -->
+      <!-- <external-path name="name" path="/" />  -->
+      <!-- <external-files-path name="name" path="path" />  -->
+      <!-- <external-cache-path name="name" path="path" />  -->
+      <!-- <external-media-path name="name" path="path" />  -->
+  </paths>
+```
+In the above make sure your path is set correctly according to where your apk is on the device. 
+
+The example above shows a fileprovider for an app local cache directory i.e something like:
+```
+/data/user/0/com.your.packagename/cache
+```
+
+For more info read the android documentation: (https://developer.android.com/reference/kotlin/androidx/core/content/FileProvider)
+
+If the file you are trying to install is on external storage you will need the read and write external storage permissions in your AndroidManifest.xml:
+```
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+```
+
+For Android SDK version 26 (8.0.0) and higher you may also be required to add the install packages permission:
+```
+  <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
+``` 
+
 ## Usage
 
 ```javascript

--- a/android/src/main/java/be/skyzohlabs/rnapk/ReactNativeAPKModule.java
+++ b/android/src/main/java/be/skyzohlabs/rnapk/ReactNativeAPKModule.java
@@ -8,7 +8,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Binder;
 import android.support.v4.content.FileProvider;
-import android.util.Log;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;


### PR DESCRIPTION
installApp method should now work with android 24 and higher if a valid fileprovider is defined. Updated the ReadMe with instructions on how to do so.