### PR TITLE
Upgrade react native

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -79,6 +79,14 @@ If running even later version of react-native you'll need to use AndroidX (e.g. 
   </application>
 ```
 
+Change dependency include in `android/app/build.gradle`: 
+
+FROM: `compile project(':react-native-apk')`
+
+TO: `implementation project(':react-native-apk')`
+
+#### Paths and permissions
+
 In android/app/src/main/res/xml folder (create it if it does not exist) add a file named filepaths.xml and paste the following contents:
 ```
   <?xml version="1.0" encoding="utf-8"?>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -36,6 +36,13 @@ $ react-native link react-native-apk
      compile project(':react-native-apk')
    ```
 
+#### SDK Breaking changes
+
+Due to major breaking changes in react-native and AndroidX please use appropiate plugin version depending on your build.
+
+ - 0.2.8 = SDK <28
+ - 1.0.0 = SDK >28 
+
 #### SDK 24 and higher
 
 As of SDK version 24 (7.0) Android requires you to set up a Fileprovider for installing apks. To do so add the following to your AndroidManifest.xml file:
@@ -52,6 +59,23 @@ As of SDK version 24 (7.0) Android requires you to set up a Fileprovider for ins
           android:resource="@xml/filepaths" />
     </provider>
 
+  </application>
+```
+
+#### SDK 28 and higher
+If running even later version of react-native you'll need to use AndroidX (e.g. build version >28).
+```
+  <application>
+   ...
+    <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
   </application>
 ```
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,23 +1,25 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet("compileSdkVersion", 26)
+    buildToolsVersion safeExtGet("buildToolsVersion", "27.0.3")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet("minSdkVersion", 16)
+        targetSdkVersion safeExtGet("targetSdkVersion", 26)
         versionCode 1
         versionName "1.0"
-        ndk {
-            abiFilters "armeabi-v7a", "x86"
-        }
     }
     lintOptions {
-       warning 'InvalidPackage'
+        abortOnError false
     }
 }
 
+
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    implementation "com.facebook.react:react-native:${safeExtGet("reactNative", "+")}" // from node_modules
 }

--- a/android/src/main/java/be/skyzohlabs/rnapk/ReactNativeAPKModule.java
+++ b/android/src/main/java/be/skyzohlabs/rnapk/ReactNativeAPKModule.java
@@ -7,7 +7,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Binder;
-import android.support.v4.content.FileProvider;
+import androidx.core.content.FileProvider;
 
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
@@ -39,9 +39,7 @@ public class ReactNativeAPKModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void isAppInstalled(String packageName, Callback cb) {
     try {
-      PackageInfo pInfo = this.reactContext.getPackageManager().getPackageInfo(packageName,
-          PackageManager.GET_ACTIVITIES);
-
+      PackageInfo pInfo = this.reactContext.getPackageManager().getPackageInfo(packageName, PackageManager.GET_ACTIVITIES);
       cb.invoke(true);
     } catch (PackageManager.NameNotFoundException e) {
       cb.invoke(false);
@@ -79,7 +77,6 @@ public class ReactNativeAPKModule extends ReactContextBaseJavaModule {
   public void getAppVersion(String packageName, Callback cb) {
     try {
       PackageInfo pInfo = this.reactContext.getPackageManager().getPackageInfo(packageName, 0);
-
       cb.invoke(pInfo.versionName);
     } catch (PackageManager.NameNotFoundException e) {
       cb.invoke(false);
@@ -89,7 +86,6 @@ public class ReactNativeAPKModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getApps(Callback cb) {
     List<PackageInfo> packages = this.reactContext.getPackageManager().getInstalledPackages(0);
-
     List<String> ret = new ArrayList<>();
     for (final PackageInfo p : packages) {
       ret.add(p.packageName);
@@ -100,7 +96,6 @@ public class ReactNativeAPKModule extends ReactContextBaseJavaModule {
   @ReactMethod
   public void getNonSystemApps(Callback cb) {
     List<PackageInfo> packages = this.reactContext.getPackageManager().getInstalledPackages(0);
-
     List<String> ret = new ArrayList<>();
     for (final PackageInfo p : packages) {
       if ((p.applicationInfo.flags & ApplicationInfo.FLAG_SYSTEM) == 0) {
@@ -114,16 +109,7 @@ public class ReactNativeAPKModule extends ReactContextBaseJavaModule {
   public void runApp(String packageName) {
     // TODO: Allow to pass Extra's from react.
     Intent launchIntent = this.reactContext.getPackageManager().getLaunchIntentForPackage(packageName);
-    //launchIntent.putExtra("test", "12331");
     this.reactContext.startActivity(launchIntent);
   }
 
-  /*@Override
-  public @Nullable Map<String, Object> getConstants() {
-      Map<String, Object> constants = new HashMap<>();
-  
-      constants.put("getApps", getApps());
-      constants.put("getNonSystemApps", getNonSystemApps());
-      return constants;
-  }*/
 }

--- a/android/src/main/java/be/skyzohlabs/rnapk/ReactNativeAPKPackage.java
+++ b/android/src/main/java/be/skyzohlabs/rnapk/ReactNativeAPKPackage.java
@@ -1,22 +1,23 @@
 package be.skyzohlabs.rnapk;
 
+import com.facebook.react.ReactPackage;
+import com.facebook.react.bridge.JavaScriptModule;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.uimanager.ViewManager;
+
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.NativeModule;
-import com.facebook.react.bridge.ReactApplicationContext;
-import com.facebook.react.uimanager.ViewManager;
-import com.facebook.react.bridge.JavaScriptModule;
-
 public class ReactNativeAPKPackage implements ReactPackage {
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-    return Arrays.<NativeModule>asList(new ReactNativeAPKModule(reactContext));
+    return Arrays.<NativeModule>asList(
+            new ReactNativeAPKModule(reactContext)
+    );
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "license": "MIT",
   "name": "react-native-apk",
   "author": "SkyzohKey <skyzohkey@protonmail.com>",
-  "version": "0.2.6",
+  "version": "1.0.0",
   "description":
     "API to install, uninstall, get version, check presence of a package, or fetch installed packages on Android.",
   "repository": {


### PR DESCRIPTION
Running a new react-native project and the plugin is outdated. Doesn't compile android project due to react-native-apk errors.

This should solve the issue. However seems due to AndroidX implementations there are breaking packages. I'm not a Java/Android developer so don't know how to solve this without the need for a breaking change version.

Maybe release this as a 1.0.0 version to symbolise a breaking change of the plugin versioning.

Possible to try it out by changing the package.json file
```"react-native-apk": "github:fbacker/react-native-apk#upgrade-react-native"```